### PR TITLE
fix: add maxContinuesFlag to copilot-cli provider (#41)

### DIFF
--- a/src/providers/builtins.test.ts
+++ b/src/providers/builtins.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_PROVIDERS } from './builtins';
+
+describe('BUILTIN_PROVIDERS', () => {
+  it('copilot-cli has maxContinuesFlag set to --max-autopilot-continues', () => {
+    const provider = BUILTIN_PROVIDERS['copilot-cli'];
+    expect(provider).toBeDefined();
+    expect(provider!.maxContinuesFlag).toBe('--max-autopilot-continues');
+  });
+
+  it('all providers with --autopilot baseArg have maxContinuesFlag defined', () => {
+    for (const [name, provider] of Object.entries(BUILTIN_PROVIDERS)) {
+      if (provider.baseArgs.includes('--autopilot')) {
+        expect(
+          provider.maxContinuesFlag,
+          `Provider "${name}" uses --autopilot but is missing maxContinuesFlag`
+        ).toBeDefined();
+        expect(
+          typeof provider.maxContinuesFlag,
+          `Provider "${name}" maxContinuesFlag should be a string`
+        ).toBe('string');
+      }
+    }
+  });
+});

--- a/src/providers/builtins.ts
+++ b/src/providers/builtins.ts
@@ -13,6 +13,7 @@ export const BUILTIN_PROVIDERS: Record<string, ProviderConfig> = {
     command: 'copilot',
     baseArgs: ['--autopilot', '--yolo'],
     modelFlag: '--model',
+    maxContinuesFlag: '--max-autopilot-continues',
     promptDelivery: 'flag',
     promptFlag: '-i',
     exitCommand: '/exit',

--- a/src/providers/registry.test.ts
+++ b/src/providers/registry.test.ts
@@ -72,6 +72,34 @@ describe('ProviderRegistry', () => {
     expect(stdin.stdinPayload).toBe('hello\n');
   });
 
+  it('includes maxContinuesFlag in args for copilot-cli', () => {
+    const registry = new ProviderRegistry();
+    const provider = registry.get('copilot-cli');
+    const copilotVariant: VariantConfig = {
+      name: 'test',
+      provider: 'copilot-cli',
+      model: 'gpt-5',
+      techStack: 'TypeScript',
+      designPhilosophy: 'Clean',
+      branch: 'variant/test'
+    };
+    const command = buildProviderCommand(provider, copilotVariant, 'hello', 25);
+    expect(command.args).toContain('--max-autopilot-continues');
+    expect(command.args).toContain('25');
+    const flagIdx = command.args.indexOf('--max-autopilot-continues');
+    expect(command.args[flagIdx + 1]).toBe('25');
+  });
+
+  it('omits maxContinuesFlag when provider does not define it', () => {
+    const providerWithoutFlag: ProviderConfig = {
+      ...baseProvider,
+      maxContinuesFlag: undefined
+    };
+    const command = buildProviderCommand(providerWithoutFlag, variant, 'hello', 10);
+    expect(command.args).not.toContain('--max-steps');
+    expect(command.args).not.toContain('10');
+  });
+
   it('discovers models via registry method using cache', async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), 'registry-disc-'));
     const arenaDir = path.join(tempDir, '.arena');


### PR DESCRIPTION
## Summary

Fixes #41 — the copilot-cli builtin provider was missing `maxContinuesFlag`, so the arena's `maxContinues` setting had no effect on Copilot agents.

## Fix

Added `maxContinuesFlag: '--max-autopilot-continues'` to the copilot-cli provider config in `src/providers/builtins.ts`. This is a **one-line fix** — the wiring in `registry.ts` already handles the flag correctly when present.

## Tests

4 new tests across 2 files:

**`src/providers/builtins.test.ts`** (new):
- copilot-cli has `maxContinuesFlag` set to correct value
- All providers with `--autopilot` baseArg have `maxContinuesFlag` defined (regression guard)

**`src/providers/registry.test.ts`** (additions):
- `maxContinuesFlag` appears in spawned command args for copilot-cli
- Flag is correctly omitted when provider doesn't define it

## Validation

- 294/294 tests pass
- `builtins.ts` line coverage: 100%
- Lint clean, TypeScript strict clean
